### PR TITLE
error due to value stored at different devcies fixed. And README typo fixed

### DIFF
--- a/matching/gnn/UltraGCN/README.md
+++ b/matching/gnn/UltraGCN/README.md
@@ -92,7 +92,7 @@ To reproduce our experimental results, we strongly suggest to use the following 
   
   ```bash
   # convert data format
-  cd data/AmazonElectronics_m1
+  cd data/Movielens1M_m1
   python convert_data.py
   
   python main.py --config_file ./config/ultragcn_movielens1m_m1.ini

--- a/matching/gnn/UltraGCN/main.py
+++ b/matching/gnn/UltraGCN/main.py
@@ -289,9 +289,13 @@ class UltraGCN(nn.Module):
         self.user_embeds = nn.Embedding(self.user_num, self.embedding_dim)
         self.item_embeds = nn.Embedding(self.item_num, self.embedding_dim)
 
-        self.constraint_mat = constraint_mat
-        self.ii_constraint_mat = ii_constraint_mat
-        self.ii_neighbor_mat = ii_neighbor_mat
+        self.constraint_mat = {}
+
+        self.constraint_mat['beta_uD'] = constraint_mat['beta_uD'].to(params['device'])
+        self.constraint_mat['beta_iD'] = constraint_mat['beta_iD'].to(params['device'])
+
+        self.ii_constraint_mat = ii_constraint_mat.to( params['device'])
+        self.ii_neighbor_mat = ii_neighbor_mat.to( params['device'])
 
         self.initial_weight = params['initial_weight']
         self.initial_weights()
@@ -544,6 +548,7 @@ def test(model, test_loader, test_ground_truth_list, mask, topk, n_user):
             batch_users = batch_users.to(model.get_device())
             rating = model.test_foward(batch_users) 
             rating = rating.cpu()
+            batch_users = batch_users.cpu()
             rating += mask[batch_users]
             
             _, rating_K = torch.topk(rating, k=topk)


### PR DESCRIPTION
## Updates

 *At matching/gnn/UltraGCN/main.py*

## before

**At line 292**

```
self. constraint_mat = constrain_mat
self.ii_constraint_mat = ii_constraint_mat
self.ii_neighbor_mat = ii_neighbor_mat
```
## after

**at line 292**
```
self.constraint_mat = {}

self.constraint_mat['beta_uD'] = constraint_mat['beta_uD'].to(params['device'])
self.constraint_mat['beta_iD'] = constraint_mat['beta_iD'].to(params['device'])
```
**At line 551**
```
batch_users = batch_users.cpu()
```
### description 

These changes remove the error 
![image](https://github.com/reczoo/RecZoo/assets/88660869/2a141b09-f94a-4054-a9eb-fc8e6dbdaeb5)

***

### README Update

**README typo fixed for Movie Lens running script**

```
cd data/AmazonElectronics_m1  -> cd data/Movielens1M_m1
```



